### PR TITLE
Conditional extra variables

### DIFF
--- a/templates/ups.conf.j2
+++ b/templates/ups.conf.j2
@@ -1,6 +1,8 @@
 # {{ ansible_managed }}
 
+{% if (nut_ups_extra is defined) and nut_ups_extra %}
 {{ nut_ups_extra }}
+{% endif %}
 
 {% for ups in nut_ups %}
 [{{ ups.name }}]

--- a/templates/upsd.conf.j2
+++ b/templates/upsd.conf.j2
@@ -1,3 +1,4 @@
 # {{ ansible_managed }}
-
+{% if (nut_upsd_extra is defined) and nut_upsd_extra %}
 {{ nut_upsd_extra }}
+{% endif %}

--- a/templates/upsmon.conf.j2
+++ b/templates/upsmon.conf.j2
@@ -16,4 +16,6 @@ NOTIFYMSG {{ notif.name }}    "{{ notif.msg }}"
 NOTIFYFLAG {{ notif.name }}    "{{ notif.flag }}"
 {% endfor %}
 
+{% if (nut_upsmon_extra is defined) and nut_upsmon_extra %}
 {{ nut_upsmon_extra }}
+{% endif %}


### PR DESCRIPTION
On Debian 12, nut-driver-enumerator.service fails to restart successfully when using configuration files generated by this role.

I traced the problem to ups.conf containing empty [] square brackets and the enumerator failing to deal with them.

These brackets are created in the jinja templates by including the (defaulted empty) nut_ups_extra variable without first checking if it has content.

This pull request adds checks on each of the 3 extra variables before including them.
